### PR TITLE
Add extension points back after refactoring

### DIFF
--- a/src/Markdown.Gist/GistBuilder.cs
+++ b/src/Markdown.Gist/GistBuilder.cs
@@ -1,13 +1,14 @@
 ﻿namespace Tanka.Markdown.Gist
 {
-    using System;
     using Blocks;
 
     public class GistBuilder : IBlockBuilder
     {
         public bool CanBuild(int start, StringRange content)
         {
-            throw new NotImplementedException();
+            bool isMatch = content.HasStringAt(start, "https://gist.github.com/");
+
+            return isMatch;
         }
 
         public Block Build(int start, StringRange content, out int end)
@@ -25,7 +26,7 @@
                 new StringRange(
                     content,
                     userNameStart,
-                    gistIdStart-1),
+                    gistIdStart - 2),
                 new StringRange(
                     content,
                     gistIdStart,

--- a/src/Markdown.HtmlTests/ExtendByAddingNewBlockRenderer.cs
+++ b/src/Markdown.HtmlTests/ExtendByAddingNewBlockRenderer.cs
@@ -19,10 +19,8 @@
             var expectedHtml = new StringBuilder();
             expectedHtml.Append("<script src=\"https://gist.github.com/pekkah/8304465.js\"></script>");
 
-            var parserOptions = MarkdownParserOptions.Defaults;
-            parserOptions.BlockFactories.Insert(0, new GistFactory());
-
-            var parser = new MarkdownParser(parserOptions);
+            var parser = new MarkdownParser();
+            parser.Builders.Insert(0, new GistBuilder());
 
             // act
             Document document = parser.Parse(markdown.ToString());

--- a/src/Markdown.HtmlTests/Markdown.HtmlTests.csproj
+++ b/src/Markdown.HtmlTests/Markdown.HtmlTests.csproj
@@ -51,7 +51,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="ExtendByAddingNewBlockRenderer.cs" />
+    <Compile Include="ExtendByAddingNewBlockRenderer.cs" />
     <Compile Include="RenderAsHtmlFeature.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Markdown/Blocks/Paragraph.cs
+++ b/src/Markdown/Blocks/Paragraph.cs
@@ -1,38 +1,25 @@
 ﻿namespace Tanka.Markdown.Blocks
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Inline;
 
     public class Paragraph : Block
     {
         private readonly List<Span> _spans;
 
-        public Paragraph(
-            StringRange parent,
-            int start,
-            int end) : base(parent, start, end)
+        public Paragraph(StringRange parent, int start, int end, IEnumerable<Span> spans) : base(parent, start, end)
         {
-            _spans = ParseSpans();
+            _spans = new List<Span>(spans);
         }
 
         public IEnumerable<Span> Spans
         {
-            get
-            {
-                return _spans;
-            }
-        }
-
-        private List<Span> ParseSpans()
-        {
-            var parser = new InlineParser();
-            return parser.Parse(this).ToList();
+            get { return _spans; }
         }
 
         public void Replace(Span target, LinkSpan withThis)
         {
-            var indexOf = _spans.IndexOf(target);
+            int indexOf = _spans.IndexOf(target);
             _spans.Remove(target);
             _spans.Insert(indexOf, withThis);
         }

--- a/src/Markdown/Blocks/ParagraphBuilder.cs
+++ b/src/Markdown/Blocks/ParagraphBuilder.cs
@@ -1,9 +1,21 @@
 ﻿namespace Tanka.Markdown.Blocks
 {
-    using Markdown;
+    using Inline;
 
     public class ParagraphBuilder : IBlockBuilder
     {
+        private readonly InlineParser _inlineParser;
+
+        public ParagraphBuilder()
+        {
+            _inlineParser = new InlineParser();
+        }
+
+        public InlineParser InlineParser
+        {
+            get { return _inlineParser; }
+        }
+
         public bool CanBuild(int start, StringRange content)
         {
             return true;
@@ -13,6 +25,13 @@
         {
             end = start;
             return null;
+        }
+
+        public Paragraph Build(int start, int end, StringRange content)
+        {
+            var spans = _inlineParser.Parse(new StringRange(content, start, end));
+
+            return new Paragraph(content, start, end, spans);
         }
     }
 }

--- a/src/Markdown/Inline/InlineParser.cs
+++ b/src/Markdown/Inline/InlineParser.cs
@@ -9,14 +9,19 @@
 
         public InlineParser()
         {
-            _spanBuilders = new List<SpanBuilder>();
-            _spanBuilders.Add(new LinkSpanBuilder());
-            _spanBuilders.Add(new ImageSpanBuilder());
-            _spanBuilders.Add(new ReferenceLinkSpanBuilder());
-            _spanBuilders.Add(new EmphasisBuilder());
+            _spanBuilders = new List<SpanBuilder>
+            {
+                new LinkSpanBuilder(),
+                new ImageSpanBuilder(),
+                new ReferenceLinkSpanBuilder(),
+                new EmphasisBuilder(),
+                new CharSpanBuilder()
+            };
+        }
 
-            // this should always be the last one
-            _spanBuilders.Add(new CharSpanBuilder());
+        public List<SpanBuilder> Builders
+        {
+            get { return _spanBuilders; }
         }
 
         public IEnumerable<Span> Parse(StringRange content)

--- a/src/MarkdownTests/ExtendByAddingNewBlock.cs
+++ b/src/MarkdownTests/ExtendByAddingNewBlock.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Text;
+    using FluentAssertions;
     using Markdown;
     using Markdown.Gist;
     using Xbehave;
@@ -17,10 +18,8 @@
             "Given markdown parser with GistFactory"
                 .Given(() =>
                 {
-                    var options = MarkdownParserOptions.Defaults;
-                    options.BlockFactories.Insert(0, new GistFactory());
-
-                    var parser = new MarkdownParser(options);
+                    var parser = new MarkdownParser();
+                    parser.Builders.Insert(0, new GistBuilder());
 
                     GivenMarkdownParser(parser);
                     GivenTheMarkdown(builder.ToString());
@@ -33,10 +32,10 @@
                 .Then(() => ThenDocumentChildrenShouldHaveCount(1));
 
             "And child at index 0 should be Gist with gist id and user name"
-                .And(() => ThenDocumentChildAtIndexShouldMatch<GistBlock>(0, new
+                .And(() => ThenDocumentChildAtIndexShould<GistBlock>(0, gist =>
                 {
-                    GistId = "8304465",
-                    UserName = "pekkah"
+                    gist.UserName.ToString().ShouldBeEquivalentTo("pekkah");
+                    gist.GistId.ToString().ShouldBeEquivalentTo("8304465");
                 }));
         }
 

--- a/src/MarkdownTests/MarkdownTests.csproj
+++ b/src/MarkdownTests/MarkdownTests.csproj
@@ -58,8 +58,8 @@
     <Compile Include="Blocks\CodeblockBuilderFacts.cs" />
     <Compile Include="Blocks\OrderedListBuilderFacts.cs" />
     <Compile Include="MarkdownParserFacts.cs" />
-    <None Include="ExtendByAddingNewSpan.cs" />
-    <None Include="ExtendByAddingNewBlock.cs" />
+    <Compile Include="ExtendByAddingNewSpan.cs" />
+    <Compile Include="ExtendByAddingNewBlock.cs" />
     <Compile Include="MarkdownParserFactsBase.cs" />
     <Compile Include="StringRangeFacts.cs" />
     <Compile Include="Inline\InlineParserFacts.cs" />


### PR DESCRIPTION
Extension points were disabled due to major refactoring of the parsing.

Add way to add:
- new block level elements
- new span level elements
