### PR TITLE
CodeBlock now holds syntax identifier information.

### DIFF
--- a/src/Markdown.Html/CodeblockRenderer.cs
+++ b/src/Markdown.Html/CodeblockRenderer.cs
@@ -12,6 +12,11 @@
             var code = new HtmlTag("code", tag);
             //code.Text(block.Code);
             code.Text(block.ToString());
+            var syntax = block.Syntax;
+            if (!string.IsNullOrWhiteSpace(syntax))
+            {
+                code.AddClass(string.Concat("lang-", syntax));
+            }
 
             return tag;
         }

--- a/src/Markdown.HtmlTests/Markdown.HtmlTests.csproj
+++ b/src/Markdown.HtmlTests/Markdown.HtmlTests.csproj
@@ -78,6 +78,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Markdown.HtmlTests/RenderAsHtmlFeature.cs
+++ b/src/Markdown.HtmlTests/RenderAsHtmlFeature.cs
@@ -67,6 +67,33 @@
         }
 
         [Fact]
+        public void RenderCodeblocksWithSyntaxName()
+        {
+            // arrange
+            var markdown = new StringBuilder();
+            markdown.AppendLine("```cs");
+            markdown.AppendLine("string name = \"test\";");
+            markdown.AppendLine("```");
+
+            var expectedHtml = new StringBuilder();
+
+            // it looks like the syntax name is prefixed with 'lang' by convention
+            expectedHtml.Append("<pre><code class=\"lang-cs\">");
+            expectedHtml.Append("string name = &quot;test&quot;;");
+            expectedHtml.Append("</code></pre>");
+
+            var parser = new MarkdownParser();
+            var renderer = new MarkdownHtmlRenderer();
+
+            // act
+            var document = parser.Parse(markdown.ToString());
+            string html = renderer.Render(document).Replace("\r\n", "");
+
+            // assert
+            html.ShouldBeEquivalentTo(expectedHtml.ToString());
+        }
+
+        [Fact]
         public void RenderOrderedLists()
         {
             // arrange

--- a/src/Markdown/Blocks/Codeblock.cs
+++ b/src/Markdown/Blocks/Codeblock.cs
@@ -1,11 +1,26 @@
+using System.Text.RegularExpressions;
+
 namespace Tanka.Markdown.Blocks
 {
     using Markdown;
 
     public class Codeblock : Block
     {
+        private readonly StringRange parent;
+
+        public string Syntax
+        {
+            get
+            {
+                var match = SyntaxIdentifieRegex.Match(parent.Document);
+                return match.Success ? match.Groups[1].Value : null;
+            }
+        }
+
+        private static readonly Regex SyntaxIdentifieRegex = new Regex("```(.*)\r");
         public Codeblock(StringRange parent, int start, int end) : base(parent, start, end)
         {
+            this.parent = parent;
         }
     }
 }

--- a/src/MarkdownTests/MarkdownParserFacts.cs
+++ b/src/MarkdownTests/MarkdownParserFacts.cs
@@ -149,6 +149,25 @@
         }
 
         [Fact]
+        public void CodeblockWithSytaxIdentifier()
+        {
+            /* given */
+            var builder = new StringBuilder();
+            builder.AppendLine("```cs");
+            builder.AppendLine("public int X = 1;");
+            builder.AppendLine("```");
+            string markdown = builder.ToString();
+
+            var parser = new MarkdownParser();
+
+            /* when */
+            Document result = parser.Parse(markdown);
+
+            /* then */
+            result.Blocks.Cast<Codeblock>().First().Syntax.ShouldAllBeEquivalentTo("cs");
+        }
+
+        [Fact]
         public void SetextHeadings()
         {
             /* given */

--- a/src/MarkdownTests/MarkdownTests.csproj
+++ b/src/MarkdownTests/MarkdownTests.csproj
@@ -91,7 +91,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
The syntax identifier that follows the ``` ticks is extracted and rendered in the <code> tag as a class name prefixed with 'lang'. e.g. 'lang-cs'.
The 'lang' prefix was only inferred from the github flavor convention so that it can be used in a post processor to perform code formatting. e.g. using ColorCode.
